### PR TITLE
added log warning if 1014 block character is unexpected

### DIFF
--- a/mciutil/mciutil.py
+++ b/mciutil/mciutil.py
@@ -27,12 +27,19 @@ def unblock(blocked_data):
     :param blocked_data: String containing 1014 blocked data or file
     :return: list of records in file
     """
-
+    block_warning_triggered = False
     file_pointer = 0
     unblock_data = []
 
     while file_pointer <= len(blocked_data):
         unblock_data.append(blocked_data[file_pointer:file_pointer+1012])
+        LOGGER.debug("Block chars [%s]", blocked_data[file_pointer+1012:file_pointer+1014])
+        if not block_warning_triggered and (
+                blocked_data[file_pointer+1012:file_pointer+1014] not in (b(''), b("\x40\x40"))):
+            LOGGER.warn("File may not be in 1014 blocked format - found unusual EOB marker %s, usually x'40'x'40'\n"
+                        "Consider using --no1014blocking option if file is VBS format",
+                        blocked_data[file_pointer+1012:file_pointer+1014])
+            block_warning_triggered = True
         file_pointer += 1014
 
     return vbs_unpack(b("").join(unblock_data))


### PR DESCRIPTION
Provides a warning to the user to state that the file being processed may not be in the 1014 block format due to the content of the block characters. Covers Enhancement #27 