### PR TITLE
Fix to DE43 extraction encoding

### DIFF
--- a/mciutil/mciutil.py
+++ b/mciutil/mciutil.py
@@ -570,14 +570,16 @@ def _get_de43_fields(de43_field):
     LOGGER.debug("de43_field=%s", de43_field)
     de43_regex = (
         r"(?P<DE43_NAME>.+?) *\\(?P<DE43_ADDRESS>.+?) *\\(?P<DE43_SUBURB>.+?) *\\"
-        r"(?P<DE43_POSTCODE>\d{4,10}) *(?P<DE43_STATE>.{3})(?P<DE43_COUNTRY>.{3})"
+        r"(?P<DE43_POSTCODE>\S{4,10}) *(?P<DE43_STATE>.{3})(?P<DE43_COUNTRY>.{3})"
     )
 
-    field_match = re.match(de43_regex, de43_field.decode())
+    field_match = re.match(de43_regex, de43_field.decode(encoding='latin-1'))
     if not field_match:
         return dict()
+
     # get the dict
     field_dict = field_match.groupdict()
+
     # set fields in dict to bytes (no effect for py2)
     for field in field_dict:
         field_dict[field] = b(field_dict[field])

--- a/mciutil/mciutil.py
+++ b/mciutil/mciutil.py
@@ -573,7 +573,7 @@ def _get_de43_fields(de43_field):
         r"(?P<DE43_POSTCODE>\S{4,10}) *(?P<DE43_STATE>.{3})(?P<DE43_COUNTRY>.{3})"
     )
 
-    field_match = re.match(de43_regex, de43_field.decode(encoding='latin-1'))
+    field_match = re.match(de43_regex, de43_field.decode('latin-1'))
     if not field_match:
         return dict()
 

--- a/tests/test_mciutil.py
+++ b/tests/test_mciutil.py
@@ -118,6 +118,15 @@ class TestGetMessageElements(TestCase):
         de43_elements = _get_de43_fields(de43_raw)
         self.assertEqual({}, de43_elements)
 
+    def test_get_de43_elements_utf8_char(self):
+        """
+        issue raised by raymond wong - unicard. Unicode de43 names causing issues
+        """
+        de43_raw = b("GOLDEN FIELD CAF\xc9\\1163 PINETREE WAY UNIT 10\\COQUITLAM\\V3B8A9    BC CAN")
+        de43_elements = _get_de43_fields(de43_raw)
+        self.assertEqual(de43_elements["DE43_NAME"], b"GOLDEN FIELD CAF\xc9")
+        self.assertEqual(de43_elements["DE43_POSTCODE"], b"V3B8A9")
+
     def test_get_de43_elements(self):
         de43_raw = b("AAMI                  \\36 WICKHAM TERRACE             "
                      "              \\BRISBANE     \\4000      QLDAUS")

--- a/tests/test_mciutil.py
+++ b/tests/test_mciutil.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 from unittest import TestCase
 import hexdump
@@ -120,12 +122,12 @@ class TestGetMessageElements(TestCase):
 
     def test_get_de43_elements_utf8_char(self):
         """
-        issue raised by raymond wong - unicard. Unicode de43 names causing issues
+        Issue #30: Latin de43 names causing issues
         """
         de43_raw = b("GOLDEN FIELD CAF\xc9\\1163 PINETREE WAY UNIT 10\\COQUITLAM\\V3B8A9    BC CAN")
         de43_elements = _get_de43_fields(de43_raw)
-        self.assertEqual(de43_elements["DE43_NAME"], b"GOLDEN FIELD CAF\xc9")
-        self.assertEqual(de43_elements["DE43_POSTCODE"], b"V3B8A9")
+        self.assertEqual(de43_elements["DE43_NAME"], b(u"GOLDEN FIELD CAFÉ"))
+        self.assertEqual(de43_elements["DE43_POSTCODE"], b("V3B8A9"))
 
     def test_get_de43_elements(self):
         de43_raw = b("AAMI                  \\36 WICKHAM TERRACE             "

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34
+envlist = py26, py27, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
Issue #30 relates to the encode/decode of latin characters. MasterCard values can contain latin characters as part of the latin-1 or ISO8859-1 but the logic to interpret DE43 was decoding to ascii which does not support the latin characters.
The fix also allows a greater variety of post codes or zip codes. Zip or postcode can now contain letters and numbers.