### PR TITLE
Update tox versions and coverage badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ MasterCard file utilities
 .. image:: https://img.shields.io/pypi/v/mciutil.svg
         :target: https://pypi.python.org/pypi/mciutil
 
-.. image:: https://coveralls.io/repos/adelosa/mciutil/badge.svg?branch=feature%2Fupdate-travis-ci-settings&service=github
-        :target: https://coveralls.io/github/adelosa/mciutil?branch=feature%2Fupdate-travis-ci-settings
+.. image:: https://coveralls.io/repos/adelosa/mciutil/badge.svg?branch=develop&service=github
+        :target: https://coveralls.io/github/adelosa/mciutil?branch=develop
 
 
 Set of command line utilities to work with various MasterCard files.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34
+envlist = py26, py27, py35
 
 [testenv]
 setenv =


### PR DESCRIPTION
Pointing to master rather than develop which seems to be the new main branch. 
Updating coverage and tox versions to point at develop.