### PR TITLE
Fix broken versioneer version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,17 @@
 
 History
 =======
+
+0.5.0 (2016-10-03)
+------------------
+* Fixed version display in release version.
+
+0.4.8 (2016-10-02)
+------------------
+* added support for latin1 encoding of csv extract
+* fixes to setup process so that mideu.yml file is installed
+* fixed de43 split to allow more formats for different countries
+
 0.4.6 (2016-08-09)
 ------------------
 * added ``--no1014blocking`` option to allow processing of VBS structure files.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,5 @@ universal = 1
 VCS = git
 style = pep440
 versionfile_source = mciutil/_version.py
+versionfile_build = mciutil/_version.py
 tag_prefix =


### PR DESCRIPTION
Fix #35. I removed a line from the setup.cfg and the build stopped creating the static version number.
V0.4.8 provides a bogus version number. Next version will provide correct version details.